### PR TITLE
Expanded routines

### DIFF
--- a/params/finetune.json
+++ b/params/finetune.json
@@ -1,0 +1,31 @@
+{
+    "model_fn": "mca",
+    "weight_name": "best_ROC-AUC_mca",
+    "number_of_tunable_layers": 10,
+    "fresh_dense_sizes": [
+        512,
+        512,
+        512
+    ],
+    "activation_fn": "relu",
+    "dropout": 0.5,
+    "batch_norm": true,
+    "num_tasks": 12,
+    "augment_smiles": true,
+    "augment_test_smiles": false,
+    "sanitize": true,
+    "canonical": false,
+    "test_canonical": true,
+    "kekulize": false,
+    "smiles_start_stop_token": true,
+    "batch_size": 256,
+    "lr": 0.00001,
+    "optimizer": "adam",
+    "loss_fn": "binary_cross_entropy_ignore_nan_and_sum",
+    "class_weights": [
+        1,
+        1
+    ],
+    "epochs": 200,
+    "save_model": 25
+}

--- a/scripts/eval_tox.py
+++ b/scripts/eval_tox.py
@@ -143,7 +143,6 @@ def main(
             [smiles_language.token_indexes_to_smiles(s.tolist()) for s in smiles_batch]
         )
         labels.extend(labels_batch.squeeze().tolist())
-        print(pred.shape, labels_batch.shape)
     # Scores are now 3D: num_samples x num_att_layers x padding_length
     attention = torch.stack(attention_scores, dim=0).numpy()
     logger.info(f'Shape of attention scores {attention.shape}.')

--- a/scripts/eval_tox.py
+++ b/scripts/eval_tox.py
@@ -14,9 +14,12 @@ from pytoda.datasets import AnnotatedDataset, SMILESDataset
 from pytoda.smiles.smiles_language import SMILESLanguage
 from toxsmi.models import MODEL_FACTORY
 from toxsmi.utils import disable_rdkit_logging
+from paccmann_predictor.utils.interpret import (
+    monte_carlo_dropout, test_time_augmentation
+)
 
 # setup logging
-# fmt: off
+# yapf: disable
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -40,19 +43,19 @@ parser.add_argument(
     help='Path to a pickle of a SMILES language object.'
 )
 parser.add_argument(
-    '-m', '--model_id', type=str,
-    help='ID for model factory', default='mca'
+    '-m', '--model_id', type=str, default='mca',
+    help='ID for model factory'
 )
-# fmt: on
+parser.add_argument(
+    '-c', '--confidence', default=True, action='store_true',
+    help='Compute sample-wise confidences'
+)
+# yapf: enable
 
 
 def main(
-    model_path,
-    smi_filepath,
-    labels_filepath,
-    output_folder,
-    smiles_language_filepath,
-    model_id,
+    model_path, smi_filepath, labels_filepath, output_folder,
+    smiles_language_filepath, model_id, confidence
 ):
 
     logging.basicConfig(level=logging.INFO, format='%(message)s')
@@ -69,10 +72,14 @@ def main(
     os.makedirs(output_folder, exist_ok=True)
 
     if model_id not in MODEL_FACTORY.keys():
-        raise KeyError(f'Model ID: Pass one of {MODEL_FACTORY.keys()}, not {model_id}')
+        raise KeyError(
+            f'Model ID: Pass one of {MODEL_FACTORY.keys()}, not {model_id}'
+        )
 
     device = get_device()
-    weights_path = os.path.join(model_path, 'weights', f'best_ROC-AUC_{model_id}.pt')
+    weights_path = os.path.join(
+        model_path, 'weights', f'best_ROC-AUC_{model_id}.pt'
+    )
 
     # Restore model
     model = MODEL_FACTORY[model_id](params).to(device)
@@ -94,7 +101,9 @@ def main(
 
     # Load language
     if smiles_language_filepath == '.':
-        smiles_language_filepath = os.path.join(model_path, 'smiles_language.pkl')
+        smiles_language_filepath = os.path.join(
+            model_path, 'smiles_language.pkl'
+        )
     smiles_language = SMILESLanguage.load(smiles_language_filepath)
 
     # Assemble datasets
@@ -120,31 +129,132 @@ def main(
         'Consider setting manually if this looks wrong.'
     )
     dataset = AnnotatedDataset(
-        annotations_filepath=labels_filepath, dataset=smiles_dataset, device=device
+        annotations_filepath=labels_filepath,
+        dataset=smiles_dataset,
+        device=device
     )
     loader = torch.utils.data.DataLoader(
-        dataset=dataset, batch_size=10, shuffle=False, drop_last=False, num_workers=0
+        dataset=dataset,
+        batch_size=10,
+        shuffle=False,
+        drop_last=False,
+        num_workers=0
     )
+    if confidence:
+        smiles_aleatoric_dataset = SMILESDataset(
+            smi_filepath,
+            smiles_language=smiles_language,
+            padding_length=params.get('smiles_padding_length', None),
+            padding=params.get('padd_smiles', True),
+            add_start_and_stop=params.get('add_start_stop_token', True),
+            augment=True,  # Natively true for aleatoric uncertainity estimate
+            canonical=params.get('canonical', False),
+            kekulize=params.get('kekulize', False),
+            all_bonds_explicit=params.get('all_bonds_explicit', False),
+            all_hs_explicit=params.get('all_hs_explicit', False),
+            randomize=params.get('randomize', False),
+            remove_bonddir=params.get('remove_bonddir', False),
+            remove_chirality=params.get('remove_chirality', False),
+            selfies=params.get('selfies', False)
+        )
+        ale_dataset = AnnotatedDataset(
+            annotations_filepath=labels_filepath,
+            dataset=smiles_aleatoric_dataset,
+            device=device
+        )
+        ale_loader = torch.utils.data.DataLoader(
+            dataset=ale_dataset,
+            batch_size=10,
+            shuffle=False,
+            drop_last=False,
+            num_workers=0
+        )
+        smiles_epi_dataset = SMILESDataset(
+            smi_filepath,
+            smiles_language=smiles_language,
+            padding_length=params.get('smiles_padding_length', None),
+            padding=params.get('padd_smiles', True),
+            add_start_and_stop=params.get('add_start_stop_token', True),
+            augment=False,  # Natively false for epistemic uncertainity estimate
+            canonical=params.get('canonical', False),
+            kekulize=params.get('kekulize', False),
+            all_bonds_explicit=params.get('all_bonds_explicit', False),
+            all_hs_explicit=params.get('all_hs_explicit', False),
+            randomize=params.get('randomize', False),
+            remove_bonddir=params.get('remove_bonddir', False),
+            remove_chirality=params.get('remove_chirality', False),
+            selfies=params.get('selfies', False)
+        )
+        epi_dataset = AnnotatedDataset(
+            annotations_filepath=labels_filepath,
+            dataset=smiles_epi_dataset,
+            device=device
+        )
+        epi_loader = torch.utils.data.DataLoader(
+            dataset=epi_dataset,
+            batch_size=10,
+            shuffle=False,
+            drop_last=False,
+            num_workers=0
+        )
 
     logger.info(
-        f'Device for data loader is {dataset.device} and for ' f'model is {device}'
+        f'Device for data loader is {dataset.device} and for '
+        f'model is {device}'
     )
     # Start evaluation
     logger.info('Evaluation about to start...\n')
 
     preds, labels, attention_scores, smiles = [], [], [], []
-    for smiles_batch, labels_batch in loader:
+    for idx, (smiles_batch, labels_batch) in enumerate(loader):
         pred, pred_dict = model(smiles_batch.to(device))
         preds.extend(pred.detach().squeeze().tolist())
         attention_scores.extend(
             torch.stack(pred_dict['smiles_attention'], dim=1).detach()
         )
         smiles.extend(
-            [smiles_language.token_indexes_to_smiles(s.tolist()) for s in smiles_batch]
+            [
+                smiles_language.token_indexes_to_smiles(s.tolist())
+                for s in smiles_batch
+            ]
         )
         labels.extend(labels_batch.squeeze().tolist())
     # Scores are now 3D: num_samples x num_att_layers x padding_length
     attention = torch.stack(attention_scores, dim=0).numpy()
+
+    if confidence:
+        # Compute uncertainity estimates and save them
+        epistemic_conf, epistemic_pred = monte_carlo_dropout(
+            model, regime='loader', loader=epi_loader
+        )
+        aleatoric_conf, aleatoric_pred = test_time_augmentation(
+            model, regime='loader', loader=ale_loader
+        )
+        epi_conf_df = pd.DataFrame(
+            data=epistemic_conf.numpy(),
+            columns=[
+                f'epistemic_conf_{i}' for i in range(epistemic_conf.shape[1])
+            ],
+        )
+        ale_conf_df = pd.DataFrame(
+            data=aleatoric_conf.numpy(),
+            columns=[
+                f'aleatoric_conf_{i}' for i in range(aleatoric_conf.shape[1])
+            ],
+        )
+        epi_pred_df = pd.DataFrame(
+            data=epistemic_pred.numpy(),
+            columns=[
+                f'epistemic_pred_{i}' for i in range(epistemic_pred.shape[1])
+            ],
+        )
+        ale_pred_df = pd.DataFrame(
+            data=aleatoric_pred.numpy(),
+            columns=[
+                f'aleatoric_pred_{i}' for i in range(aleatoric_pred.shape[1])
+            ],
+        )
+
     logger.info(f'Shape of attention scores {attention.shape}.')
     np.save(os.path.join(output_folder, 'attention_raw.npy'), attention)
     attention_avg = np.mean(attention, axis=1)
@@ -160,7 +270,12 @@ def main(
         data=labels,
         columns=[f'label_{i}' for i in range(len(labels[0]))],
     )
-    df = pd.concat([pred_df, lab_df, att_df], axis=1)
+    df = pd.concat([pred_df, lab_df], axis=1)
+    if confidence:
+        df = pd.concat(
+            [df, epi_conf_df, ale_conf_df, epi_pred_df, ale_pred_df], axis=1
+        )
+    df = pd.concat([df, att_df], axis=1)
     df.insert(0, 'SMILES', smiles)
     df.to_csv(os.path.join(output_folder, 'results.csv'), index=False)
 
@@ -170,10 +285,7 @@ def main(
 if __name__ == '__main__':
     args = parser.parse_args()
     main(
-        args.model_path,
-        args.smi_filepath,
-        args.labels_filepath,
-        args.output_folder,
-        args.smiles_language_filepath,
-        args.model_id,
+        args.model_path, args.smi_filepath, args.labels_filepath,
+        args.output_folder, args.smiles_language_filepath, args.model_id,
+        args.confidence
     )

--- a/scripts/eval_tox.py
+++ b/scripts/eval_tox.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Test toxsmi predictor."""
+import argparse
+import json
+import logging
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import torch
+from paccmann_predictor.utils.utils import get_device
+from pytoda.datasets import AnnotatedDataset, SMILESDataset
+from pytoda.smiles.smiles_language import SMILESLanguage
+from toxsmi.models import MODEL_FACTORY
+from toxsmi.utils import disable_rdkit_logging
+
+# setup logging
+# fmt: off
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    'model_path', type=str,
+    help='Path to the trained model'
+)
+parser.add_argument(
+    'smi_filepath', type=str,
+    help='Path to the SMILES data (.smi)'
+)
+parser.add_argument(
+    'labels_filepath', type=str,
+    help='Path to the test toxicity scores (.csv)'
+)
+parser.add_argument(
+    'output_folder', type=str,
+    help='Directory where the output .csv will be stored.'
+)
+parser.add_argument(
+    '-s', '--smiles_language_filepath', type=str, default='.',
+    help='Path to a pickle of a SMILES language object.'
+)
+parser.add_argument(
+    '-m', '--model_id', type=str,
+    help='ID for model factory', default='mca'
+)
+# fmt: on
+
+
+def main(
+    model_path,
+    smi_filepath,
+    labels_filepath,
+    output_folder,
+    smiles_language_filepath,
+    model_id,
+):
+
+    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    logger = logging.getLogger('eval_toxicity')
+    logger.setLevel(logging.INFO)
+    disable_rdkit_logging()
+
+    # Process parameter file:
+    params = {}
+    with open(os.path.join(model_path, 'model_params.json'), 'r') as fp:
+        params.update(json.load(fp))
+
+    # Create model directory
+    os.makedirs(output_folder, exist_ok=True)
+
+    if model_id not in MODEL_FACTORY.keys():
+        raise KeyError(f'Model ID: Pass one of {MODEL_FACTORY.keys()}, not {model_id}')
+
+    device = get_device()
+    weights_path = os.path.join(model_path, 'weights', f'best_ROC-AUC_{model_id}.pt')
+
+    # Restore model
+    model = MODEL_FACTORY[model_id](params).to(device)
+    if os.path.isfile(weights_path):
+        try:
+            model.load(weights_path, map_location=device)
+        except Exception:
+            logger.error(f'Error in model restoring from {weights_path}')
+    else:
+        logger.info(
+            f'Did not find weights at {weights_path}, '
+            f'name weights: "best_ROC-AUC_{model_id}.pt".'
+        )
+    model.eval()
+
+    logger.info('Model restored. Model specs & parameters follow')
+    for name, param in model.named_parameters():
+        logger.info((name, param.shape))
+
+    # Load language
+    if smiles_language_filepath == '.':
+        smiles_language_filepath = os.path.join(model_path, 'smiles_language.pkl')
+    smiles_language = SMILESLanguage.load(smiles_language_filepath)
+
+    # Assemble datasets
+    smiles_dataset = SMILESDataset(
+        smi_filepath,
+        smiles_language=smiles_language,
+        padding_length=params.get('smiles_padding_length', None),
+        padding=params.get('padd_smiles', True),
+        add_start_and_stop=params.get('add_start_stop_token', True),
+        augment=params.get('augment_test_smiles', False),
+        canonical=params.get('test_canonical', False),
+        kekulize=params.get('test_kekulize', False),
+        all_bonds_explicit=params.get('test_all_bonds_explicit', False),
+        all_hs_explicit=params.get('test_all_hs_explicit', False),
+        randomize=False,
+        remove_bonddir=params.get('test_remove_bonddir', False),
+        remove_chirality=params.get('test_remove_chirality', False),
+        selfies=params.get('selfies', False),
+        sanitize=params.get('test_sanitize', False),
+    )
+    logger.info(
+        f'SMILES Padding length is {smiles_dataset._dataset.padding_length}.'
+        'Consider setting manually if this looks wrong.'
+    )
+    dataset = AnnotatedDataset(
+        annotations_filepath=labels_filepath, dataset=smiles_dataset, device=device
+    )
+    loader = torch.utils.data.DataLoader(
+        dataset=dataset, batch_size=10, shuffle=False, drop_last=False, num_workers=0
+    )
+
+    logger.info(
+        f'Device for data loader is {dataset.device} and for ' f'model is {device}'
+    )
+    # Start evaluation
+    logger.info('Evaluation about to start...\n')
+
+    target_preds = []
+    attention_scores = []
+    smiles = []
+    for smiles_batch, labels_batch in loader:
+        preds, pred_dict = model(smiles_batch.to(device))
+        target_preds.extend(preds.detach().squeeze().tolist())
+        attention_scores.extend(
+            torch.stack(pred_dict['smiles_attention'], dim=1).detach()
+        )
+        smiles.extend(
+            [smiles_language.token_indexes_to_smiles(s.tolist()) for s in smiles_batch]
+        )
+    # Scores are now 3D: num_samples x num_att_layers x padding_length
+    attention = torch.stack(attention_scores, dim=0).numpy()
+    logger.info(f'Shape of attention scores {attention.shape}.')
+    np.save(os.path.join(output_folder, 'attention_raw.npy'), attention)
+    attention_avg = np.mean(attention, axis=1)
+    att_df = pd.DataFrame(
+        data=attention_avg,
+        columns=[f'att_idx_{i}' for i in range(attention_avg.shape[1])],
+    )
+    lab_df = pd.DataFrame(
+        data=target_preds,
+        columns=[f'class_{i}' for i in range(len(target_preds[0]))],
+    )
+    df = pd.concat([lab_df, att_df], axis=1)
+    df.insert(0, 'SMILES', smiles)
+    df.to_csv(os.path.join(output_folder, 'results.csv'), index=False)
+
+    logger.info('Done, shutting down.')
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    main(
+        args.model_path,
+        args.smi_filepath,
+        args.labels_filepath,
+        args.output_folder,
+        args.smiles_language_filepath,
+        args.model_id,
+    )

--- a/scripts/eval_tox.py
+++ b/scripts/eval_tox.py
@@ -148,14 +148,14 @@ def main(
             padding=params.get('padd_smiles', True),
             add_start_and_stop=params.get('add_start_stop_token', True),
             augment=True,  # Natively true for aleatoric uncertainity estimate
-            canonical=params.get('canonical', False),
-            kekulize=params.get('kekulize', False),
-            all_bonds_explicit=params.get('all_bonds_explicit', False),
-            all_hs_explicit=params.get('all_hs_explicit', False),
-            randomize=params.get('randomize', False),
-            remove_bonddir=params.get('remove_bonddir', False),
-            remove_chirality=params.get('remove_chirality', False),
-            selfies=params.get('selfies', False)
+            canonical=params.get('test_canonical', False),
+            kekulize=params.get('test_kekulize', False),
+            all_bonds_explicit=params.get('test_all_bonds_explicit', False),
+            all_hs_explicit=params.get('test_all_hs_explicit', False),
+            remove_bonddir=params.get('test_remove_bonddir', False),
+            remove_chirality=params.get('test_remove_chirality', False),
+            selfies=params.get('selfies', False),
+            sanitize=params.get('test_sanitize', False),
         )
         ale_dataset = AnnotatedDataset(
             annotations_filepath=labels_filepath,
@@ -176,14 +176,14 @@ def main(
             padding=params.get('padd_smiles', True),
             add_start_and_stop=params.get('add_start_stop_token', True),
             augment=False,  # Natively false for epistemic uncertainity estimate
-            canonical=params.get('canonical', False),
-            kekulize=params.get('kekulize', False),
-            all_bonds_explicit=params.get('all_bonds_explicit', False),
-            all_hs_explicit=params.get('all_hs_explicit', False),
-            randomize=params.get('randomize', False),
-            remove_bonddir=params.get('remove_bonddir', False),
-            remove_chirality=params.get('remove_chirality', False),
-            selfies=params.get('selfies', False)
+            canonical=params.get('test_canonical', False),
+            kekulize=params.get('test_kekulize', False),
+            all_bonds_explicit=params.get('test_all_bonds_explicit', False),
+            all_hs_explicit=params.get('test_all_hs_explicit', False),
+            remove_bonddir=params.get('test_remove_bonddir', False),
+            remove_chirality=params.get('test_remove_chirality', False),
+            selfies=params.get('selfies', False),
+            sanitize=params.get('test_sanitize', False),
         )
         epi_dataset = AnnotatedDataset(
             annotations_filepath=labels_filepath,

--- a/scripts/finetune_tox.py
+++ b/scripts/finetune_tox.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Finetune a toxsmi predictor on a new task."""
+import argparse
+import json
+import logging
+import os
+import sys
+from time import time
+
+import numpy as np
+import torch
+from paccmann_predictor.utils.hyperparams import (
+    ACTIVATION_FN_FACTORY, OPTIMIZER_FACTORY
+)
+from paccmann_predictor.utils.layers import dense_layer
+from paccmann_predictor.utils.utils import get_device
+from pytoda.datasets import AnnotatedDataset, SMILESDataset
+from pytoda.smiles.smiles_language import SMILESLanguage
+from sklearn.metrics import (
+    auc, average_precision_score, precision_recall_curve, roc_curve
+)
+from toxsmi.models import MODEL_FACTORY
+from toxsmi.utils import disable_rdkit_logging
+from toxsmi.utils.layers import EnsembleLayer
+from toxsmi.utils.transferlearning import update_mca_model
+
+# setup logging
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    'train_scores_filepath',
+    type=str,
+    help='Path to the training toxicity scores (.csv)'
+)
+parser.add_argument(
+    'test_scores_filepath',
+    type=str,
+    help='Path to the test toxicity scores (.csv)'
+)
+parser.add_argument(
+    'smi_filepath', type=str, help='Path to the SMILES data (.smi)'
+)
+parser.add_argument('model_path', type=str, help='Directory of trained model.')
+parser.add_argument(
+    'params_filepath',
+    type=str,
+    help='Path to the .json with params for transfer learning'
+)
+parser.add_argument('training_name', type=str, help='Name for the training.')
+
+
+def main(
+    train_scores_filepath, test_scores_filepath, smi_filepath, model_path,
+    params_filepath, training_name
+):
+
+    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    logger = logging.getLogger(f'{training_name}')
+    logger.setLevel(logging.INFO)
+    disable_rdkit_logging()
+    device = get_device()
+
+    # Restore pretrained model
+    logger.info('Start model restoring.')
+    try:
+        with open(os.path.join(model_path, 'model_params.json'), 'r') as fp:
+            params = json.load(fp)
+        smiles_language = SMILESLanguage.load(
+            os.path.join(model_path, 'smiles_language.pkl')
+        )
+        model = MODEL_FACTORY[params.get('model_fn', 'mca')](params).to(device)
+        # Try weight restoring
+        try:
+            weight_path = os.path.join(
+                model_path, 'weights',
+                params.get('weights_name', 'best_ROC-AUC_mca.pt')
+            )
+            model.load(weight_path)
+        except Exception:
+            try:
+                wp = os.listdir(os.path.join(model_path, 'weights'))[0]
+                logger.info(
+                    f"Weights {weight_path} not found. Try restore {wp}"
+                )
+                model.load(os.path.join(model_path, 'weights', wp))
+            except Exception:
+                raise Exception('Error in weight loading.')
+
+    except Exception:
+        raise Exception(
+            'Error in model restoring. model_path should point to the model root '
+            'folder that contains a model_params.json, a smiles_language.pkl and a '
+            'weights folder.'
+        )
+    logger.info('Model restored. Now starting to craft it for the task')
+
+    # Process parameter file:
+    model_params = {}
+    with open(params_filepath) as fp:
+        model_params.update(json.load(fp))
+
+    model = update_mca_model(model, model_params)
+
+    logger.info('Model set up.')
+    for idx, (name, param) in enumerate(model.named_parameters()):
+        logger.info(
+            (idx, name, param.shape, f'Gradients: {param.requires_grad}')
+        )
+
+    ft_model_path = os.path.join(model_path, 'finetuned')
+    os.makedirs(os.path.join(ft_model_path, 'weights'), exist_ok=True)
+    os.makedirs(os.path.join(ft_model_path, 'results'), exist_ok=True)
+
+    logger.info('Now start data preprocessing...')
+
+    # Assemble datasets
+    smiles_dataset = SMILESDataset(
+        smi_filepath,
+        smiles_language=smiles_language,
+        padding_length=params.get('smiles_padding_length', None),
+        padding=params.get('padd_smiles', True),
+        add_start_and_stop=params.get('add_start_stop_token', True),
+        augment=params.get('augment_smiles', False),
+        canonical=params.get('canonical', False),
+        kekulize=params.get('kekulize', False),
+        all_bonds_explicit=params.get('all_bonds_explicit', False),
+        all_hs_explicit=params.get('all_hs_explicit', False),
+        randomize=params.get('randomize', False),
+        remove_bonddir=params.get('remove_bonddir', False),
+        remove_chirality=params.get('remove_chirality', False),
+        selfies=params.get('selfies', False),
+        sanitize=params.get('sanitize', True)
+    )
+
+    train_dataset = AnnotatedDataset(
+        annotations_filepath=train_scores_filepath,
+        dataset=smiles_dataset,
+        device=get_device()
+    )
+    train_loader = torch.utils.data.DataLoader(
+        dataset=train_dataset,
+        batch_size=params['batch_size'],
+        shuffle=True,
+        drop_last=True,
+        num_workers=params.get('num_workers', 0)
+    )
+
+    # Generally, if sanitize is True molecules are de-kekulized. Augmentation
+    # preserves the "kekulization", so if it is used, test data should be
+    # sanitized or canonicalized.
+    smiles_test_dataset = SMILESDataset(
+        smi_filepath,
+        smiles_language=smiles_language,
+        padding_length=params.get('smiles_padding_length', None),
+        padding=params.get('padd_smiles', True),
+        add_start_and_stop=params.get('add_start_stop_token', True),
+        augment=params.get('augment_test_smiles', False),
+        canonical=params.get('test_canonical', False),
+        kekulize=params.get('test_kekulize', False),
+        all_bonds_explicit=params.get('test_all_bonds_explicit', False),
+        all_hs_explicit=params.get('test_all_hs_explicit', False),
+        randomize=False,
+        remove_bonddir=params.get('test_remove_bonddir', False),
+        remove_chirality=params.get('test_remove_chirality', False),
+        selfies=params.get('selfies', False),
+        sanitize=params.get('test_sanitize', False)
+    )
+
+    # Dump eventually modified SMILES Language
+    smiles_language.save(os.path.join(ft_model_path, 'smiles_language.pkl'))
+
+    test_dataset = AnnotatedDataset(
+        annotations_filepath=test_scores_filepath,
+        dataset=smiles_test_dataset,
+        device=get_device()
+    )
+
+    test_loader = torch.utils.data.DataLoader(
+        dataset=test_dataset,
+        batch_size=params['batch_size'],
+        shuffle=False,
+        drop_last=False,
+        num_workers=params.get('num_workers', 0)
+    )
+
+    save_top_model = os.path.join(ft_model_path, 'weights/{}_{}_{}.pt')
+
+    num_t_params = sum(
+        p.numel() for p in model.parameters() if p.requires_grad
+    )
+    num_params = sum(p.numel() for p in model.parameters())
+    params.update({'params': num_params, 'trainable_params': num_t_params})
+    logger.info(
+        f'Number of parameters: {num_params} (trainable {num_t_params}).'
+    )
+
+    # Define optimizer only for those layers which require gradients
+    optimizer = (
+        OPTIMIZER_FACTORY[params.get('optimizer', 'adam')](
+            filter(lambda p: p.requires_grad, model.parameters()),
+            lr=params.get('lr', 0.00001)
+        )
+    )
+    # Dump params.json file with updated parameters.
+    with open(os.path.join(ft_model_path, 'model_params.json'), 'w') as fp:
+        json.dump(params, fp)
+
+    # Start training
+    logger.info('Training about to start...\n')
+    t = time()
+    min_loss, max_roc_auc = 1000000, 0
+    max_precision_recall_score = 0
+
+    for epoch in range(params['epochs']):
+
+        model.train()
+        logger.info(params_filepath.split('/')[-1])
+        logger.info(f"== Epoch [{epoch}/{params['epochs']}] ==")
+        train_loss = 0
+
+        for ind, (smiles, y) in enumerate(train_loader):
+
+            smiles = torch.squeeze(smiles.to(device))
+            y_hat, pred_dict = model(smiles)
+
+            loss = model.loss(y_hat, y.to(device))
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            train_loss += loss.item()
+
+        logger.info(
+            '\t **** TRAINING ****   '
+            f"Epoch [{epoch + 1}/{params['epochs']}], "
+            f'loss: {train_loss / len(train_loader):.5f}. '
+            f'This took {time() - t:.1f} secs.'
+        )
+        t = time()
+
+        # Measure validation performance
+        model.eval()
+        with torch.no_grad():
+            test_loss = 0
+            predictions = []
+            labels = []
+            for ind, (smiles, y) in enumerate(test_loader):
+
+                smiles = torch.squeeze(smiles.to(device))
+
+                y_hat, pred_dict = model(smiles)
+                predictions.append(y_hat)
+                # Copy y tensor since loss function applies downstream modification
+                labels.append(y.clone())
+                loss = model.loss(y_hat, y.to(device))
+                test_loss += loss.item()
+
+        predictions = torch.cat(predictions, dim=0).flatten().cpu().numpy()
+        labels = torch.cat(labels, dim=0).flatten().cpu().numpy()
+
+        # Remove NaNs from labels to compute scores
+        predictions = predictions[~np.isnan(labels)]
+        labels = labels[~np.isnan(labels)]
+        test_loss_a = test_loss / len(test_loader)
+        fpr, tpr, _ = roc_curve(labels, predictions)
+        test_roc_auc_a = auc(fpr, tpr)
+
+        # calculations for visualization plot
+        precision, recall, _ = precision_recall_curve(labels, predictions)
+        # score for precision vs accuracy
+        test_precision_recall_score = average_precision_score(
+            labels, predictions
+        )
+
+        logger.info(
+            f"\t **** TEST **** Epoch [{epoch + 1}/{params['epochs']}], "
+            f'loss: {test_loss_a:.5f}, , roc_auc: {test_roc_auc_a:.5f}, '
+            f'avg precision-recall score: {test_precision_recall_score:.5f}'
+        )
+        info = {
+            'test_auc': test_roc_auc_a,
+            'train_loss': train_loss / len(train_loader),
+            'test_loss': test_loss_a,
+            'test_auc': test_roc_auc_a,
+            'best_test_auc': max_roc_auc,
+            'test_precision_recall_score': test_precision_recall_score,
+            'best_precision_recall_score': max_precision_recall_score,
+        }
+
+        def save(path, metric, typ, val=None):
+            model.save(path.format(typ, metric, params.get('model_fn', 'mca')))
+            if typ == 'best':
+                logger.info(
+                    f'\t New best performance in {metric}'
+                    f' with value : {val:.7f} in epoch: {epoch+1}'
+                )
+
+        if test_roc_auc_a > max_roc_auc:
+            max_roc_auc = test_roc_auc_a
+            info.update({'best_test_auc': max_roc_auc})
+            save(save_top_model, 'ROC-AUC', 'best', max_roc_auc)
+            np.save(
+                os.path.join(ft_model_path, 'results', 'best_predictions.npy'),
+                predictions
+            )
+            with open(
+                os.path.join(ft_model_path, 'results', 'metrics.json'), 'w'
+            ) as f:
+                json.dump(info, f)
+
+        if test_precision_recall_score > max_precision_recall_score:
+            max_precision_recall_score = test_precision_recall_score
+            info.update(
+                {'best_precision_recall_score': max_precision_recall_score}
+            )
+            save(
+                save_top_model, 'precision-recall score', 'best',
+                max_precision_recall_score
+            )
+
+        if test_loss_a < min_loss:
+            min_loss = test_loss_a
+            save(save_top_model, 'loss', 'best', min_loss)
+            ep_loss = epoch
+
+        if (epoch + 1) % params.get('save_model', 100) == 0:
+            save(save_top_model, 'epoch', str(epoch))
+
+    logger.info(
+        'Overall best performances are: \n \t'
+        f'Loss = {min_loss:.4f} in epoch {ep_loss} '
+    )
+    save(save_top_model, 'training', 'done')
+    logger.info('Done with training, models saved, shutting down.')
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    main(
+        args.train_scores_filepath, args.test_scores_filepath,
+        args.smi_filepath, args.model_path, args.params_filepath,
+        args.training_name
+    )

--- a/scripts/finetune_tox.py
+++ b/scripts/finetune_tox.py
@@ -9,10 +9,7 @@ from time import time
 
 import numpy as np
 import torch
-from paccmann_predictor.utils.hyperparams import (
-    ACTIVATION_FN_FACTORY, OPTIMIZER_FACTORY
-)
-from paccmann_predictor.utils.layers import dense_layer
+from paccmann_predictor.utils.hyperparams import OPTIMIZER_FACTORY
 from paccmann_predictor.utils.utils import get_device
 from pytoda.datasets import AnnotatedDataset, SMILESDataset
 from pytoda.smiles.smiles_language import SMILESLanguage
@@ -21,7 +18,6 @@ from sklearn.metrics import (
 )
 from toxsmi.models import MODEL_FACTORY
 from toxsmi.utils import disable_rdkit_logging
-from toxsmi.utils.layers import EnsembleLayer
 from toxsmi.utils.transferlearning import update_mca_model
 
 # setup logging

--- a/scripts/train_tox.py
+++ b/scripts/train_tox.py
@@ -151,7 +151,7 @@ def main(
     ):
         raise ValueError(
             'Epistemic uncertainty evaluation not supported if augmentation '
-            'is enabled for test data.'
+            'is not enabled for test data.'
         )
 
     # Generally, if sanitize is True molecules are de-kekulized. Augmentation
@@ -174,6 +174,10 @@ def main(
         selfies=params.get('selfies', False),
         sanitize=params.get('test_sanitize', False)
     )
+
+    # Dump eventually modified SMILES Language
+    smiles_language.save(os.path.join(model_dir, 'smiles_language.pkl'))
+
     logger.info(smiles_dataset._dataset.transform)
     logger.info(smiles_test_dataset._dataset.transform)
 
@@ -236,7 +240,7 @@ def main(
     model = MODEL_FACTORY[params.get('model_fn', 'mca')](params).to(device)
     logger.info(model)
 
-    logger.info(f'Parameters follow')
+    logger.info('Parameters follow')
     for name, param in model.named_parameters():
         logger.info((name, param.shape))
 

--- a/scripts/train_tox.py
+++ b/scripts/train_tox.py
@@ -320,8 +320,6 @@ def main(
         # Remove NaNs from labels to compute scores
         predictions = predictions[~np.isnan(labels)]
         labels = labels[~np.isnan(labels)]
-        logger.info('length labels:', len(labels), labels)
-        logger.info('length predictions:', len(predictions), predictions)
         test_loss_a = test_loss / len(test_loader)
         fpr, tpr, _ = roc_curve(labels, predictions)
         test_roc_auc_a = auc(fpr, tpr)

--- a/toxsmi/__init__.py
+++ b/toxsmi/__init__.py
@@ -1,3 +1,3 @@
 """Initialization for `toxsmi` module."""
-__version__ = '0.0.2'
+__version__ = '0.0.2.1'
 __name__ = 'toxsmi'

--- a/toxsmi/models/mca.py
+++ b/toxsmi/models/mca.py
@@ -1,9 +1,9 @@
 import pickle
 from collections import OrderedDict
+from typing import Tuple
 
 import torch
 import torch.nn as nn
-
 from paccmann_predictor.utils.hyperparams import ACTIVATION_FN_FACTORY
 from paccmann_predictor.utils.layers import (
     alpha_projection, convolutional_layer, dense_layer, smiles_projection
@@ -23,7 +23,7 @@ class MCAMultiTask(nn.Module):
         - MultiLabel classification implementation (sigmoidal in last layer)
     """
 
-    def __init__(self, params, *args, **kwargs):
+    def __init__(self, params: dict, *args, **kwargs):
         """Constructor.
 
         Args:
@@ -243,7 +243,7 @@ class MCAMultiTask(nn.Module):
             params.get('loss_fn', 'binary_cross_entropy_ignore_nan_and_sum')
         ]   # yapf: disable
 
-    def forward(self, smiles):
+    def forward(self, smiles: torch.Tensor) -> Tuple[torch.Tensor, dict]:
         """Forward pass through the MCA.
 
         Args:
@@ -298,14 +298,14 @@ class MCAMultiTask(nn.Module):
         }
         return predictions, prediction_dict
 
-    def loss(self, yhat, y):
+    def loss(self, yhat: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         return self.loss_fn(yhat, y)
 
-    def load(self, path, *args, **kwargs):
+    def load(self, path: str, *args, **kwargs) -> None:
         """Load model from path."""
         weights = torch.load(path, *args, **kwargs)
         self.load_state_dict(weights)
 
-    def save(self, path, *args, **kwargs):
+    def save(self, path: str, *args, **kwargs) -> None:
         """Save model to path."""
         torch.save(self.state_dict(), path, *args, **kwargs)

--- a/toxsmi/models/mca.py
+++ b/toxsmi/models/mca.py
@@ -242,6 +242,11 @@ class MCAMultiTask(nn.Module):
         self.loss_fn = LOSS_FN_FACTORY[
             params.get('loss_fn', 'binary_cross_entropy_ignore_nan_and_sum')
         ]   # yapf: disable
+        # Set class weights manually
+        if 'binary_cross_entropy_ignore_nan' in params.get(
+            'loss_fn', 'binary_cross_entropy_ignore_nan_and_sum'
+        ):
+            self.loss_fn.class_weights = params.get('class_weights', [1, 1])
 
     def forward(self, smiles: torch.Tensor) -> Tuple[torch.Tensor, dict]:
         """Forward pass through the MCA.
@@ -250,7 +255,7 @@ class MCAMultiTask(nn.Module):
             smiles (torch.Tensor): type int and shape: [batch_size, seq_length]
 
         Returns:
-            (torch.Tensor, torch.Tensor): predictions, prediction_dict
+            (torch.Tensor, dict): predictions, prediction_dict
 
             predictions are toxicity predictions of shape `[bs, num_tasks]`.
             prediction_dict includes the prediction and attention weights.

--- a/toxsmi/utils/transferlearning.py
+++ b/toxsmi/utils/transferlearning.py
@@ -1,0 +1,96 @@
+""""Utils for model finetuning"""
+import torch.nn as nn
+from toxsmi.models import MCAMultiTask
+import logging
+from collections import OrderedDict
+from paccmann_predictor.utils.layers import dense_layer
+from paccmann_predictor.utils.hyperparams import ACTIVATION_FN_FACTORY
+from toxsmi.utils.layers import EnsembleLayer
+from paccmann_predictor.utils.utils import get_device
+
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+logger = logging.getLogger(__name__)
+
+
+def update_mca_model(model: MCAMultiTask, params: dict) -> MCAMultiTask:
+    """
+    Receives a pretrained model (instance of MCAMultiTask), modifies it and returns
+    the updated object
+
+    Args:
+        model (MCAMultiTask): Pretrained model to be modified.
+        params (dict): Hyperparameter file for the modifications. Needs to include:
+            - number_of_tunable_layers (how many layers should not be frozen. If
+                number exceeds number of existing layers, all layers are tuned.)
+            - fresh_dense_sizes (a list of fresh dense layers to be plugged in at
+                the end).
+            - num_tasks (number of classfication tasks being performed).
+
+    Returns:
+        MCAMultiTask: Modified model for finetune
+    """
+
+    if not isinstance(model, MCAMultiTask):
+        raise TypeError(
+            f'Wrong model type, was {type(model)}, not MCAMultiTask.'
+        )
+
+    # Freeze the correct layers and add new ones
+    # Not strictly speaking all layers, but all param matrices, gradient-req or not.
+    num_layers = len(['' for p in model.parameters()])
+    num_to_tune = params['number_of_tunable_layers']
+    if num_to_tune > num_layers:
+        logger.warning(
+            f'Model has {num_layers} tunable layers. Given # is larger: {num_to_tune}.'
+        )
+        num_to_tune = num_layers
+    fresh_sizes = params['fresh_dense_sizes']
+    logger.info(
+        f'Model has {num_layers} layers. {num_to_tune} will be finetuned, '
+        f'{len(fresh_sizes)} fresh ones will be added (sizes: {fresh_sizes}).'
+    )
+    # Count the ensemble layers (will be replaced anyways)
+    num_ensemble_layers = len(
+        list(
+            filter(lambda tpl: 'ensemble' in tpl[0], model.named_parameters())
+        )
+    )
+    # Freeze the right layers
+    for idx, (name, param) in enumerate(model.named_parameters()):
+        if idx < num_layers - num_to_tune - num_ensemble_layers:
+            param.requires_grad = False
+
+    # Add more dense layers
+    fresh_sizes.insert(0, model.hidden_sizes[-1])
+    model.dense_layers = nn.Sequential(
+        model.dense_layers,
+        nn.Sequential(
+            OrderedDict(
+                [
+                    (
+                        'fresh_dense_{}'.format(ind),
+                        dense_layer(
+                            fresh_sizes[ind],
+                            fresh_sizes[ind + 1],
+                            act_fn=ACTIVATION_FN_FACTORY[
+                                params.get('activation_fn', 'relu')],
+                            dropout=params.get('dropout', 0.5),
+                            batch_norm=params.get('batch_norm', True)
+                        ).to(get_device())
+                    ) for ind in range(len(fresh_sizes) - 1)
+                ]
+            )
+        )
+    )
+
+    # Replace final layer
+    model.num_tasks = params['num_tasks']
+    model.final_dense = EnsembleLayer(
+        typ=params.get('ensemble', 'score'),
+        input_size=fresh_sizes[-1],
+        output_size=model.num_tasks,
+        ensemble_size=params.get('ensemble_size', 5),
+        fn=ACTIVATION_FN_FACTORY['sigmoid']
+    )
+
+    return model

--- a/toxsmi/utils/wrappers.py
+++ b/toxsmi/utils/wrappers.py
@@ -1,6 +1,11 @@
+import logging
+from typing import Iterable
+
 import torch
 import torch.nn as nn
 from paccmann_predictor.utils.utils import get_device
+
+logger = logging.getLogger(__name__)
 
 DEVICE = get_device()
 
@@ -8,18 +13,41 @@ DEVICE = get_device()
 class BCEIgnoreNaN(nn.Module):
     """Wrapper for BCE function that ignores NaNs"""
 
-    def __init__(self, reduction):
+    def __init__(self, reduction: str, class_weights: tuple = (1, 3)) -> None:
+        """
+
+        Args:
+            reduction (str): Reduction applied in loss function. Either sum or mean.
+            class_weights (tuple, optional): Class weights for loss function.
+                Defaults to (1, 1), i.e. equal class weighhts.
+        """
         super(BCEIgnoreNaN, self).__init__()
         self.loss = nn.BCELoss(reduction='none')
-        self.reduction = reduction
-        if reduction != 'sum' and reduction != 'mean':
-            raise ValueError('Reduction type is mean or sum')
 
-    def forward(self, yhat, y):
+        if reduction != 'sum' and reduction != 'mean':
+            raise ValueError(f'Chose reduction type as mean or sum, not {reduction}')
+        self.reduction = reduction
+
+        if not isinstance(class_weights, Iterable):
+            raise TypeError(f'Pass iterable for weights, not: {type(class_weights)}')
+        if not len(class_weights) == 2:
+            raise ValueError(f'Class weight len should be 2, not: {len(class_weights)}')
+        if not all(w > 0 for w in class_weights):
+            raise ValueError(f'All weigths should be positive not: {class_weights}')
+
+        self.class_weights = class_weights
+        logger.info(f'Class weights are {class_weights}.')
+
+    def forward(self, yhat: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         """
         Arguments:
-            y (torch.Tensor): Labels
-            yhat (torch.Tensor): Predictions
+            y (torch.Tensor): Labels (1D or 2D).
+            yhat (torch.Tensor): Predictions (1D or 2D).
+
+        NOTE: This function has side effects (in-place modification of labels).
+        This is needed since deepcopying the tensor destroys gradient flow. Just be
+        aware that repeated calls of this function with the same variables lead to
+        different results if and only if at least one nan is in y.
 
         Returns:
             torch.Tensor: BCE loss
@@ -27,10 +55,17 @@ class BCEIgnoreNaN(nn.Module):
 
         # Find position of NaNs, set them to 0 to well-define BCE loss and
         # then filter them out
-
         nans = ~torch.isnan(y)
         y[y != y] = 0
-        out = self.loss(yhat, y) * nans.type(torch.float32).to(DEVICE)
+        loss = self.loss(yhat, y) * nans.type(torch.float32).to(DEVICE)
+
+        # Set a tensor with class weights, equal shape to labels.
+        # NaNs are 0 in y now, but since loss is 0, downstream calc is unaffected.
+        weight_tensor = torch.ones(y.shape)
+        weight_tensor[y == 0.0] = self.class_weights[0]
+        weight_tensor[y == 1.0] = self.class_weights[1]
+
+        out = loss * weight_tensor
 
         if self.reduction == 'mean':
             return torch.mean(out)

--- a/toxsmi/utils/wrappers.py
+++ b/toxsmi/utils/wrappers.py
@@ -25,15 +25,23 @@ class BCEIgnoreNaN(nn.Module):
         self.loss = nn.BCELoss(reduction='none')
 
         if reduction != 'sum' and reduction != 'mean':
-            raise ValueError(f'Chose reduction type as mean or sum, not {reduction}')
+            raise ValueError(
+                f'Chose reduction type as mean or sum, not {reduction}'
+            )
         self.reduction = reduction
 
         if not isinstance(class_weights, Iterable):
-            raise TypeError(f'Pass iterable for weights, not: {type(class_weights)}')
+            raise TypeError(
+                f'Pass iterable for weights, not: {type(class_weights)}'
+            )
         if not len(class_weights) == 2:
-            raise ValueError(f'Class weight len should be 2, not: {len(class_weights)}')
+            raise ValueError(
+                f'Class weight len should be 2, not: {len(class_weights)}'
+            )
         if not all(w > 0 for w in class_weights):
-            raise ValueError(f'All weigths should be positive not: {class_weights}')
+            raise ValueError(
+                f'All weigths should be positive not: {class_weights}'
+            )
 
         self.class_weights = class_weights
         logger.info(f'Class weights are {class_weights}.')

--- a/toxsmi/utils/wrappers.py
+++ b/toxsmi/utils/wrappers.py
@@ -13,7 +13,7 @@ DEVICE = get_device()
 class BCEIgnoreNaN(nn.Module):
     """Wrapper for BCE function that ignores NaNs"""
 
-    def __init__(self, reduction: str, class_weights: tuple = (1, 3)) -> None:
+    def __init__(self, reduction: str, class_weights: tuple = (1, 1)) -> None:
         """
 
         Args:


### PR DESCRIPTION
Few new features added, mostly:

- Model evaluation script (`eval_tox.py`) that saves predictions, aleatoric and epistemic confidences and attention scores to disk
- Routines for model finetuning. A script `finetune_tox.py` restores a pretrained model,  freezes a flexible number of layers and adds a flexible number of fresh dense layers.
- some fixes in existing code (typing, better reporting, docstring)

